### PR TITLE
Fix baseURL scope in loader

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -1,9 +1,8 @@
+const baseURL = document.currentScript?.src
+  .replace(/\/js\/loader\.js.*$/, '') || '';
+
 (async function iniciarLoader() {
   console.log('🚀 loader.js ejecutándose...');
-
-  // Ruta base para cargar recursos incluso si la aplicación está en un subdirectorio
-  const baseURL = document.currentScript?.src
-    .replace(/\/js\/loader\.js.*$/, '') || '';
 
   try {
     const usuario = JSON.parse(localStorage.getItem('usuario'));


### PR DESCRIPTION
## Summary
- move `baseURL` variable outside the loader initialization function
- ensure `cargarModulo` can access `baseURL`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869ccdaef7483259e97616aa9b32dce