### PR TITLE
Fix API fetch paths and centralize base URL

### DIFF
--- a/js/config/apiConfig.js
+++ b/js/config/apiConfig.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'http://localhost:3000';

--- a/js/helpers/enviar.js
+++ b/js/helpers/enviar.js
@@ -3,6 +3,7 @@ import { validarDatosGenerales, validarModuloEspecifico } from './validaciones.j
 import { mostrarModalExito, mostrarModalError } from './modalExito.js';
 import { obtenerAreaDestino } from './areaDestino.js';
 import { detectarModulos } from './detectarModulos.js';
+import { API_BASE_URL } from '../config/apiConfig.js';
 
 export async function enviarFormularioSinRespuesta(datos) {
   const boton = document.getElementById('btnEnviarFormulario');
@@ -48,7 +49,7 @@ console.log("🚀 JSON a enviar al servidor:");
 console.log(JSON.stringify(datosCompletos, null, 2));  // 👈 con sangrado de 2 espaci
 
     // 📨 POST único
-    const res = await fetch('/api/crear-carpeta', {
+    const res = await fetch(`${API_BASE_URL}/api/crear-carpeta`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(datosCompletos)

--- a/js/pedidos/accionesPedido.js
+++ b/js/pedidos/accionesPedido.js
@@ -1,8 +1,10 @@
+import { API_BASE_URL } from '../config/apiConfig.js';
+
 async function actualizarEstadoPedido(idTramite, nuevoEstado, motivo = "", botonClicado = null) {
   bloquearBotonesAccion(botonClicado);
 
   try {
-    const respuesta = await fetch("/api/actualizar-estado", {
+    const respuesta = await fetch(`${API_BASE_URL}/api/actualizar-estado`, {
       method: "POST",
       body: JSON.stringify({
         accion: "actualizarEstado",

--- a/js/reenvio/reenviarService.js
+++ b/js/reenvio/reenviarService.js
@@ -1,4 +1,5 @@
 import { mostrarModalExito, mostrarModalError } from '../helpers/modalExito.js';
+import { API_BASE_URL } from '../config/apiConfig.js';
 
 export async function reenviarPedido(datosBase) {
   const boton = document.getElementById('btn-reenviar-definitivo');
@@ -40,7 +41,7 @@ export async function reenviarPedido(datosBase) {
 
     console.log("📦 Payload completo para reenviar:", payload);
 
-    const res = await fetch('/api/reenviar-pedido', {
+    const res = await fetch(`${API_BASE_URL}/api/reenviar-pedido`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- add `API_BASE_URL` constant
- update fetch calls to use the new base URL

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6869cef6fdcc83258a7decd9f7f7e8a3