### PR TITLE
Actualizar frontend a GAS directo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Contrataciones Web v1
+
+Este proyecto corresponde al frontend de la aplicación de solicitudes. Para la versión **v1** se consume directamente la Web App de Google Apps Script como backend. Las llamadas ya no pasan por el proxy Node.js.
+
+## Despliegue en GitHub Pages
+
+1. Realiza un fork o clona este repositorio en GitHub.
+2. En la configuración del repositorio selecciona **Pages** y apunta a la rama principal (`main`) en la carpeta raíz.
+3. Guarda los cambios y GitHub Pages publicará el sitio estático.
+
+El sitio funcionará sin necesidad de levantar `server.js` ni instalar Node.js. Todas las peticiones `fetch` se envían directamente a Google Apps Script.
+
+## Backend
+
+Los endpoints consumidos son Web Apps de Google Apps Script:
+
+- Crear carpeta: `https://script.google.com/macros/s/AKfycbw0Xp3sWFdG6Enbd3AW2fbEyu3PZxvXW-8czq2ZLG5uksFIdUKN7n9tJjFj-EQQp-qf/exec`
+- Actualizar estado: `https://script.google.com/macros/s/AKfycbyny2IjeG_Xeg4BTEM979-cW5e7PMmApj-WhS9X29Q46GAh-tEC7mJoY66TV94gpgJe_w/exec`
+- Reenviar pedido: `https://script.google.com/macros/s/AKfycbyCpB-_Xdop5qHhih13WArlQ9YfYYXSYT2BBeXGH3EY0IX8J7Q5qiVD6e-JkuUHqxI/exec`
+
+Estos endpoints están definidos en `js/config/apiConfig.js` y son utilizados por el código JavaScript del proyecto.
+

--- a/js/config/apiConfig.js
+++ b/js/config/apiConfig.js
@@ -1,1 +1,4 @@
-export const API_BASE_URL = 'http://localhost:3000';
+// URLs directos de la Web App de Google Apps Script
+export const API_URL_CREAR_CARPETA = 'https://script.google.com/macros/s/AKfycbw0Xp3sWFdG6Enbd3AW2fbEyu3PZxvXW-8czq2ZLG5uksFIdUKN7n9tJjFj-EQQp-qf/exec';
+export const API_URL_ACTUALIZAR_ESTADO = 'https://script.google.com/macros/s/AKfycbyny2IjeG_Xeg4BTEM979-cW5e7PMmApj-WhS9X29Q46GAh-tEC7mJoY66TV94gpgJe_w/exec';
+export const API_URL_REENVIAR_PEDIDO = 'https://script.google.com/macros/s/AKfycbyCpB-_Xdop5qHhih13WArlQ9YfYYXSYT2BBeXGH3EY0IX8J7Q5qiVD6e-JkuUHqxI/exec';

--- a/js/helpers/enviar.js
+++ b/js/helpers/enviar.js
@@ -3,7 +3,7 @@ import { validarDatosGenerales, validarModuloEspecifico } from './validaciones.j
 import { mostrarModalExito, mostrarModalError } from './modalExito.js';
 import { obtenerAreaDestino } from './areaDestino.js';
 import { detectarModulos } from './detectarModulos.js';
-import { API_BASE_URL } from '../config/apiConfig.js';
+import { API_URL_CREAR_CARPETA } from '../config/apiConfig.js';
 
 export async function enviarFormularioSinRespuesta(datos) {
   const boton = document.getElementById('btnEnviarFormulario');
@@ -49,7 +49,7 @@ console.log("🚀 JSON a enviar al servidor:");
 console.log(JSON.stringify(datosCompletos, null, 2));  // 👈 con sangrado de 2 espaci
 
     // 📨 POST único
-    const res = await fetch(`${API_BASE_URL}/api/crear-carpeta`, {
+    const res = await fetch(API_URL_CREAR_CARPETA, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(datosCompletos)

--- a/js/pedidos/accionesPedido.js
+++ b/js/pedidos/accionesPedido.js
@@ -1,10 +1,10 @@
-import { API_BASE_URL } from '../config/apiConfig.js';
+import { API_URL_ACTUALIZAR_ESTADO } from '../config/apiConfig.js';
 
 async function actualizarEstadoPedido(idTramite, nuevoEstado, motivo = "", botonClicado = null) {
   bloquearBotonesAccion(botonClicado);
 
   try {
-    const respuesta = await fetch(`${API_BASE_URL}/api/actualizar-estado`, {
+    const respuesta = await fetch(API_URL_ACTUALIZAR_ESTADO, {
       method: "POST",
       body: JSON.stringify({
         accion: "actualizarEstado",

--- a/js/reenvio/reenviarService.js
+++ b/js/reenvio/reenviarService.js
@@ -1,5 +1,5 @@
 import { mostrarModalExito, mostrarModalError } from '../helpers/modalExito.js';
-import { API_BASE_URL } from '../config/apiConfig.js';
+import { API_URL_REENVIAR_PEDIDO } from '../config/apiConfig.js';
 
 export async function reenviarPedido(datosBase) {
   const boton = document.getElementById('btn-reenviar-definitivo');
@@ -41,7 +41,7 @@ export async function reenviarPedido(datosBase) {
 
     console.log("📦 Payload completo para reenviar:", payload);
 
-    const res = await fetch(`${API_BASE_URL}/api/reenviar-pedido`, {
+    const res = await fetch(API_URL_REENVIAR_PEDIDO, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- replace localhost API base URL with direct Apps Script endpoints
- adjust JS helpers to use new endpoint constants
- add README explaining deployment on GitHub Pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix proxi test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869d6daeabc8325b988c600315bfa69