### PR TITLE
Add CORS headers in Google Apps Script

### DIFF
--- a/api/google_sheets.gs
+++ b/api/google_sheets.gs
@@ -7,6 +7,18 @@ function doPost(e) {
   fila.push(datos.secretaria || "");
   fila.push(datos.fecha || "");
   hoja.appendRow(fila);
-  return ContentService.createTextOutput(JSON.stringify({ status: "ok" }))
-    .setMimeType(ContentService.MimeType.JSON);
+  return ContentService
+    .createTextOutput(JSON.stringify({ status: 'ok' }))
+    .setMimeType(ContentService.MimeType.JSON)
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Headers', 'Content-Type')
+    .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+}
+
+function doOptions() {
+  return ContentService
+    .createTextOutput('')
+    .setHeader('Access-Control-Allow-Origin', '*')
+    .setHeader('Access-Control-Allow-Headers', 'Content-Type')
+    .setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
 }


### PR DESCRIPTION
## Summary
- add CORS headers in the Apps Script
- expose `doOptions` handler

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869dbdf7dc883259af54ea082acbb5c