### PR TITLE
Expose base URL for dynamic modules

### DIFF
--- a/js/reenvio/loader-reenvio.js
+++ b/js/reenvio/loader-reenvio.js
@@ -5,6 +5,9 @@
   const baseURL = document.currentScript?.src
     .replace(/\/js\/reenvio\/loader-reenvio\.js.*$/, '') || '';
 
+  // Exponer globalmente la URL base para que la utilicen los módulos cargados dinámicamente
+  window.BASE_URL_REENVIO = baseURL;
+
   try {
     const urlParams = new URLSearchParams(window.location.search);
     const id = urlParams.get("id");

--- a/js/reenvio/reenviarService.js
+++ b/js/reenvio/reenviarService.js
@@ -43,17 +43,23 @@ export async function reenviarPedido(datosBase) {
 
     console.log("📦 Payload completo para reenviar:", payload);
 
-    if (!validarDatosGenerales(datos) || !validarModuloEspecifico(datos.modulo, datos)) {
-  alert('❌ Los datos no son válidos para reenviar.');
-  return;
-}
+    // Validar datos antes de enviar
+    if (!validarDatosGenerales(datosBase) ||
+        !validarModuloEspecifico(datosBase.modulo, datosActualizados)) {
+      mostrarModalError('Los datos no son válidos para reenviar.');
+      return;
+    }
 
 
     const res = await fetch(API_URL_REENVIAR_PEDIDO, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify(payload)
     });
+
+    if (!res.ok) {
+      throw new Error('Respuesta no válida del servidor');
+    }
 
     const json = await res.json();
     console.log("📨 Respuesta del backend:", json);
@@ -66,7 +72,7 @@ export async function reenviarPedido(datosBase) {
 
   } catch (err) {
     console.error("❌ Error al reenviar:", err);
-    alert("❌ Hubo un problema al reenviar el pedido.");
+    mostrarModalError(err.message || 'Hubo un problema al reenviar el pedido.');
   } finally {
     if (boton) {
       boton.disabled = false;

--- a/modulos/obras/obras.js
+++ b/modulos/obras/obras.js
@@ -71,7 +71,13 @@ async function cargarListaObrasExistentes() {
     const obraSelect = document.getElementById('obra');
     if (!obraSelect) return;
 
-    const obras = await fetch('../componentes/listas/obras_existentes.json').then(r => r.json());
+    const base = window.BASE_URL_REENVIO || '';
+    const url = `${base}/componentes/listas/obras_existentes.json`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`No se pudo obtener la lista de obras. (${res.status})`);
+    }
+    const obras = await res.json();
     obraSelect.innerHTML = '<option value="">Seleccione una obra...</option>';
     obras.forEach(item => {
       const valor = typeof item === 'string' ? item : item.nombre;


### PR DESCRIPTION
## Summary
- expose `window.BASE_URL_REENVIO` from the loader
- use that global base URL from `obras.js`
- improve error handling in `reenviarService`

## Testing
- `npm test` *(fails: Missing script)*
- `(cd proxi && npm test)` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686abb4cf3608325aff211f93a0eb0ab